### PR TITLE
Fix : Twacker and sample source only support BMP transfers now

### DIFF
--- a/twacker/DCA_ACQ.C
+++ b/twacker/DCA_ACQ.C
@@ -922,7 +922,7 @@ static void DoFileTransfer(HWND hWnd)
 			lstrcpy(Filename, SetupMsgGet.FileName);
 		}
 		lstrcpy(setup.FileName,Filename);//,sizeof(Filename));
-		setup.Format = TWFF_TIFF;
+		setup.Format = TWFF_BMP;
 		setup.VRefNum = 0;
 
 		/*


### PR DESCRIPTION
According to the comment, I guess this may be a coding miss

```
		/*
		* NOTE: Twacker and sample source only support BMP transfers at this
		* time - SMC 11 MAY 95
		*/
```